### PR TITLE
Convert step files to Raspberry Flavoured Markdown

### DIFF
--- a/en/code/editor-storytime-complete/main.py
+++ b/en/code/editor-storytime-complete/main.py
@@ -19,7 +19,7 @@ else:
     description = "young"
 
 # Possible choices 
-things = ["slay", "cakes", "chocolate", "rocks", "kittens"]
+things = ["goblins", "cakes", "chocolate", "rocks", "kittens"]
 friends = ["Amilyn", "Lila", "Nuala", "Idris", "Jonah", "Ari"]
 actions = ["slay", "kiss", "save", "marry", "rescue", "eat"]
 places = ["Middle Earth", "Narnia", "Hogwarts", "Alderaan"]
@@ -32,7 +32,7 @@ place = choice(places)
 
 # Parts of the story
 start = "Once upon a time, there was a " + size + " dragon called " + name + "."
-description = name + " was very " + place + "."
+description = " " + name + " was a very " + description + " dragon."
 hobby = " It liked to " + action + " " + thing + "."
 problem = " Sadly, the dragon was so great at this that it ran out of " + thing + "."
 helper = " Luckily the dragon had a friend called " + friend + " who knew where to find more " + thing + "."

--- a/en/meta.yml
+++ b/en/meta.yml
@@ -1,4 +1,4 @@
-title: Editor storytime
+title: Story time
 hero_image: images/banner.png
 description: default-project-template description
 version: 1

--- a/en/step_1.md
+++ b/en/step_1.md
@@ -1,23 +1,15 @@
-<h2 class="c-project-heading--task">Output your first line</h2>
+## Output your first line
 
 The story time program generates a story and prints it to the screen so that you can read it.
 
 First, use the `print` function to display text in the 'Text output' area of the Editor.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 1
-line_highlights: 3
----
+```python line_numbers="true" line_number_start="1" line_highlights="3"
 from random import choice
 
 print("We are going to hear a story about a dragon!")
 
---- /code ---
-</div>
+```
 
 ## Now run your code
 

--- a/en/step_10.md
+++ b/en/step_10.md
@@ -1,12 +1,14 @@
-<h2 class="c-project-heading--task">Challenge</h2>
+## Challenge
 
 Make your story even more interesting by adding some more lists with items that your program can pick from.
 
-<h2 class="c-project-heading--explainer">Here are some ideas</h2>
-
-For example, you could create a list of `enemies` or `heroes`. Or give the dragon more detail: you could create a list called `colours` that decides what colour the dragon's scales are, or a list called `breath` that determines whether the dragon breathes fire, steam, or frost.
-
-Your story can be as long as you like. The only limit is your imagination!
+> [!CHALLENGE]
+>
+> ## Here are some ideas
+>
+> For example, you could create a list of `enemies` or `heroes`. Or give the dragon more detail: you could create a list called `colours` that decides what colour the dragon's scales are, or a list called `breath` that determines whether the dragon breathes fire, steam, or frost.
+>
+> Your story can be as long as you like. The only limit is your imagination!
 
 ## Now run your code
 

--- a/en/step_2.md
+++ b/en/step_2.md
@@ -1,4 +1,4 @@
-<h2 class="c-project-heading--task">Get the dragon's name</h2>
+## Get the dragon's name
 
 Create a new variable called `name`.
 
@@ -6,22 +6,14 @@ Use the `input` function to ask the user for the dragon's name.
 
 Store the input in the new `name` variable.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 1
-line_highlights: 5
----
+```python line_numbers="true" line_number_start="1" line_highlights="5"
 from random import choice
 
 print("We are going to hear a story about a dragon!")
 
 name = input("What is the name of the dragon? ")
 
---- /code ---
-</div>
+```
 
 ## Now run your code
 

--- a/en/step_3.md
+++ b/en/step_3.md
@@ -1,4 +1,4 @@
-<h2 class="c-project-heading--task">Join the story parts</h2>
+## Join the story parts
 
 Add another line of code to print the name of the dragon to the screen.
 
@@ -6,14 +6,7 @@ Use the `name` variable to print the name to the screen.
 
 In Python, you can use the `+` operator to join strings together.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 1
-line_highlights: 6
----
+```python line_numbers="true" line_number_start="1" line_highlights="6"
 from random import choice
 
 print("We are going to hear a story about a dragon!")
@@ -21,8 +14,7 @@ print("We are going to hear a story about a dragon!")
 name = input("What is the name of the dragon? ")
 print("Excellent. The dragon is called " + name)
 
---- /code ---
-</div>
+```
 
 ## Now run your code
 

--- a/en/step_4.md
+++ b/en/step_4.md
@@ -1,15 +1,8 @@
-<h2 class="c-project-heading--task">Size and age of the dragon</h2>
+## Size and age of the dragon
 
 It's time to get some more information about the dragon.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 1
-line_highlights: 8-12
----
+```python line_numbers="true" line_number_start="1" line_highlights="8-12"
 from random import choice
 
 print("We are going to hear a story about a dragon!")
@@ -23,8 +16,7 @@ print("It was a " + size + " dragon")
 age = input("How old is the dragon? ")
 print("The dragon is " + age + " years old")
 
---- /code ---
-</div>
+```
 
 ## Now run your code
 

--- a/en/step_5.md
+++ b/en/step_5.md
@@ -1,4 +1,4 @@
-<h2 class="c-project-heading--task">Is the dragon old?</h2>
+## Is the dragon old?
 
 Dragons live for a long time.
 
@@ -12,14 +12,7 @@ With the **greater than** operator (`>`), you can test whether a number is large
 
 **Notice**: You must **type cast** the `age` variable, so the computer uses it as a **number** and not a **character string**. In Python, there is a big difference between the **characters** `1` `0` `0` and the **number** `100`.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 1
-line_highlights: 14-19
----
+```python line_numbers="true" line_number_start="1" line_highlights="14-19"
 from random import choice
 
 print("We are going to hear a story about a dragon!")
@@ -34,14 +27,13 @@ age = input("How old is the dragon? ")
 print("The dragon is " + age + " years old")
 
 if int(age) > 1000:
-    description = "an old"
+    description = "old"
 else:
-    description = "a young"
+    description = "young"
 
-print("It was an " + description + " dragon.")
+print("The dragon is " + description + ".")
 
---- /code ---
-</div>
+```
 
 ## Now run your code
 

--- a/en/step_6.md
+++ b/en/step_6.md
@@ -1,4 +1,4 @@
-<h2 class="c-project-heading--task">Add some random details</h2>
+## Add some random details
 
 Your program will generate a lot of the story at random.
 
@@ -10,14 +10,7 @@ Create a list of things that the dragon can interact with.
 
 Use the list of items we use here, or add your own items!
 
-<div class="c-project-code">
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 1
-line_highlights: 21
----
+```python line_numbers="true" line_number_start="1" line_highlights="21"
 from random import choice
 
 print("We are going to hear a story about a dragon!")
@@ -32,16 +25,15 @@ age = input("How old is the dragon? ")
 print("The dragon is " + age + " years old")
 
 if int(age) > 1000:
-    description = "an old"
+    description = "old"
 else:
-    description = "a young"
+    description = "young"
 
-print("It was an " + description + " dragon.")
+print("The dragon is " + description + ".")
 
 things = ["goblins", "cakes", "chocolate", "rocks", "trees"]
 
---- /code ---
-</div>
+```
 
 ## Now run your code
 

--- a/en/step_7.md
+++ b/en/step_7.md
@@ -1,4 +1,4 @@
-<h2 class="c-project-heading--task">Add MORE random details!</h2>
+## Add MORE random details!
 
 Add some more lists for:
 
@@ -8,23 +8,15 @@ Add some more lists for:
 
 Make three more lists that have the names `friends`, `actions`, and `places`.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 19
-line_highlights: 22-24
----
-print("It was an " + description + " dragon.")
+```python line_numbers="true" line_number_start="19" line_highlights="22-24"
+print("The dragon is " + description + ".")
 
 things = ["goblins", "cakes", "chocolate", "rocks", "trees"]
 friends = ["Amilyn", "Lila", "Nuala", "Idris", "Jonah", "Ari"]
 actions = ["slay", "kiss", "save", "marry", "rescue", "eat"]
 places = ["Middle Earth", "Narnia", "Hogwarts", "Alderaan"]
 
---- /code ---
-</div>
+```
 
 ## Now run your code
 

--- a/en/step_8.md
+++ b/en/step_8.md
@@ -1,4 +1,4 @@
-<h2 class="c-project-heading--task">Choose random details</h2>
+## Choose random details
 
 Randomly pick one item from each list.
 
@@ -10,14 +10,7 @@ Create a variable called `friend`.
 
 Assign the new variable a random item from the `friends` list and use the `friend` variable in a `print` function.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 21
-line_highlights: 26-27
----
+```python line_numbers="true" line_number_start="21" line_highlights="26-27"
 things = ["goblins", "cakes", "chocolate", "rocks", "trees"]
 friends = ["Amilyn", "Lila", "Nuala", "Idris", "Jonah", "Ari"]
 actions = ["slay", "kiss", "save", "marry", "rescue", "eat"]
@@ -26,16 +19,13 @@ places = ["Middle Earth", "Narnia", "Hogwarts", "Alderaan"]
 friend = choice(friends)
 print("The friend is " + friend)
 
---- /code ---
-</div>
+```
+
+> [!INFO]
+>
+> Check the output. Each time you run the code, the variable should be randomly assigned a new item from the `friends` list.
 
 ## Step 2
-
-Check the output.
-
-Each time you run the code, the variable should be randomly assigned a new item from the `friends` list.
-
-## Step 3
 
 **Delete** the print line.
 
@@ -43,14 +33,7 @@ Create three more variables called `action`, `place`, and `thing`.
 
 Assign them random items from the `actions`, `places`, and `things` lists.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 21
-line_highlights: 27-29
----
+```python line_numbers="true" line_number_start="21" line_highlights="27-29"
 things = ["goblins", "cakes", "chocolate", "rocks", "trees"]
 friends = ["Amilyn", "Lila", "Nuala", "Idris", "Jonah", "Ari"]
 actions = ["slay", "kiss", "save", "marry", "rescue", "eat"]
@@ -61,8 +44,7 @@ thing = choice(things)
 action = choice(actions)
 place = choice(places)
 
---- /code ---
-</div>
+```
 
 ## Now run your code
 

--- a/en/step_9.md
+++ b/en/step_9.md
@@ -1,27 +1,16 @@
-<h2 class="c-project-heading--task">Tell your story</h2>
+## Tell your story
 
 Now you can have some fun with creating your story!
 
 Be as imaginative and creative as you like.
 
-## Step 1
-
 First, type `story =` to create a variable to store your story in.
 
 Now use all the variables you have to make an imaginative story of your own. There is an example provided below, but you can make any story you like.
 
-## Step 2
-
 Write your story putting the variables together. Then on the last line of your program, print the story to the screen.
 
-<div class="c-project-code">
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 21
-line_highlights: 31-33
----
+```python line_numbers="true" line_number_start="21" line_highlights="31-33"
 things = ["goblins", "cakes", "chocolate", "rocks", "trees"]
 friends = ["Amilyn", "Lila", "Nuala", "Idris", "Jonah", "Ari"]
 actions = ["slay", "kiss", "save", "marry", "rescue", "eat"]
@@ -36,8 +25,7 @@ story = "Once upon a time, there was a dragon called " + name + ". The dragon wa
 
 print(story)
 
---- /code ---
-</div>
+```
 
 ## Now run your code
 


### PR DESCRIPTION
Converts all step files to the Raspberry Flavoured Markdown spec, fixes story text/logic bugs, and corrects the title.

**Branch reconciliation:** `draft` is an orphan (no shared history with `master`); includes a keep-draft ("ours") merge so the PR is mergeable — draft's content is authoritative.

**Conversion**
- Headings → `##`; step_8 run-and-observe section → `> [!INFO]`; single-task steps no sub-heading; step_10 challenge → `> [!CHALLENGE]`
- Code → fenced blocks (inline attrs, code preserved)

**Story text/logic fixes (agreed before PR)**
- steps 5/6/7: `description` was `"an old"`/`"a young"` then printed as `"It was an " + description` → "It was an **an old** dragon". Changed to bare `"old"`/`"young"` and `print("The dragon is " + description + ".")` (matches step 5's stated expected output). Step 9's `"a very " + description + " creature"` now reads correctly.
- `editor-storytime-complete/main.py`: line 35 no longer overwrites `description` with `name + " was very " + place` (which produced "Sparky was very Narnia."); it now builds a sensible sentence using the old/young result. `things` list: `"slay"` (an action) → `"goblins"`.

**Meta**
- Title `Editor storytime` → `Story time` (dropped the repo-slug prefix)

**Flagged for editorial (not changed):** the complete reference assembles the story via separate `start`/`hobby`/… variables while step 9 builds one inline string — a structural divergence to reconcile separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)